### PR TITLE
Add Chapter 4 interactive demos

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,7 +108,11 @@
                     </ul>
                 </li>
                 <li><a href="#chapter4" class="chapter-link" data-chapter="chapter4">Chapter 4: Systems Based on
-                        Numbers</a></li>
+                        Numbers</a>
+                    <ul class="sub-chapter-list">
+                        <li><a href="interactive/chapter4-demos.html" class="chapter-link external-demo-link" target="_blank" rel="noopener">🔬 Interactive Demos: Number-Based Systems</a></li>
+                    </ul>
+                </li>
                 <li><a href="#chapter5" class="chapter-link" data-chapter="chapter5">Chapter 5: Two Dimensions and
                         Beyond</a></li>
                 <li><a href="#chapter6" class="chapter-link" data-chapter="chapter6">Chapter 6: Starting from

--- a/interactive/chapter4-demos.html
+++ b/interactive/chapter4-demos.html
@@ -1,0 +1,614 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Chapter 4: Systems Based on Numbers - Interactive Demos</title>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+            background: linear-gradient(135deg, #050505 0%, #111111 100%);
+            color: #e6e6e6;
+            line-height: 1.6;
+            min-height: 100vh;
+        }
+
+        a {
+            color: inherit;
+        }
+
+        .container {
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 2.5rem 1.5rem 4rem;
+        }
+
+        .header {
+            text-align: center;
+            margin-bottom: 3.5rem;
+            padding: 2.5rem 1.5rem;
+            background: rgba(255, 255, 255, 0.05);
+            backdrop-filter: blur(12px);
+            border: 1px solid rgba(255, 255, 255, 0.1);
+            border-radius: 18px;
+        }
+
+        .header h1 {
+            font-size: clamp(2.4rem, 5vw, 3.4rem);
+            font-weight: 700;
+            margin-bottom: 1rem;
+            background: linear-gradient(135deg, #ffd700, #ffed4e);
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+            background-clip: text;
+        }
+
+        .header p {
+            font-size: 1.1rem;
+            opacity: 0.85;
+            max-width: 760px;
+            margin: 0 auto;
+        }
+
+        .demo-section {
+            margin: 3.5rem 0;
+            padding: 2.25rem;
+            background: rgba(255, 255, 255, 0.03);
+            border: 1px solid rgba(255, 255, 255, 0.08);
+            border-radius: 22px;
+            backdrop-filter: blur(8px);
+        }
+
+        .demo-title {
+            font-size: clamp(1.8rem, 4vw, 2.6rem);
+            font-weight: 600;
+            margin-bottom: 0.75rem;
+            color: #ffd700;
+            display: flex;
+            align-items: center;
+            gap: 0.75rem;
+        }
+
+        .demo-title span.icon {
+            font-size: 2.2rem;
+        }
+
+        .demo-description {
+            font-size: 1.05rem;
+            margin-bottom: 1.75rem;
+            opacity: 0.85;
+            line-height: 1.7;
+        }
+
+        .demo-container {
+            background: rgba(0, 0, 0, 0.35);
+            border-radius: 18px;
+            padding: 1.75rem;
+            border: 1px solid rgba(255, 255, 255, 0.08);
+        }
+
+        .controls {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 1rem 1.5rem;
+            margin-bottom: 1.5rem;
+            align-items: center;
+        }
+
+        .control-group {
+            display: flex;
+            flex-direction: column;
+            gap: 0.4rem;
+            min-width: 160px;
+        }
+
+        .control-group label {
+            font-size: 0.85rem;
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+            opacity: 0.75;
+        }
+
+        select,
+        input[type="range"],
+        input[type="number"] {
+            background: rgba(255, 255, 255, 0.08);
+            border: 1px solid rgba(255, 255, 255, 0.15);
+            border-radius: 10px;
+            color: #ffd700;
+            padding: 0.55rem 0.75rem;
+            font-size: 0.95rem;
+            font-family: inherit;
+            outline: none;
+        }
+
+        input[type="range"] {
+            accent-color: #ffd700;
+            width: 220px;
+        }
+
+        .btn {
+            padding: 0.7rem 1.4rem;
+            background: rgba(255, 215, 0, 0.12);
+            border: 1px solid #ffd700;
+            border-radius: 10px;
+            color: #ffd700;
+            cursor: pointer;
+            font-weight: 500;
+            transition: all 0.25s ease;
+        }
+
+        .btn:hover {
+            background: rgba(255, 215, 0, 0.22);
+            transform: translateY(-1px);
+        }
+
+        .btn.secondary {
+            border-color: rgba(255, 255, 255, 0.25);
+            color: rgba(255, 255, 255, 0.8);
+            background: rgba(255, 255, 255, 0.06);
+        }
+
+        .btn.secondary:hover {
+            background: rgba(255, 255, 255, 0.12);
+        }
+
+        .canvas-container {
+            display: flex;
+            flex-direction: column;
+            gap: 1rem;
+        }
+
+        canvas {
+            border: 1px solid rgba(255, 255, 255, 0.08);
+            border-radius: 14px;
+            background: #050505;
+            max-width: 100%;
+        }
+
+        .info-panel {
+            background: rgba(255, 215, 0, 0.07);
+            border-left: 4px solid #ffd700;
+            padding: 1rem 1.25rem;
+            border-radius: 0 14px 14px 0;
+            margin-top: 1.5rem;
+        }
+
+        .info-panel h3 {
+            text-transform: uppercase;
+            font-size: 0.9rem;
+            letter-spacing: 0.1em;
+            margin-bottom: 0.6rem;
+            opacity: 0.85;
+        }
+
+        .info-panel p {
+            font-size: 0.95rem;
+            opacity: 0.85;
+        }
+
+        .stat-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+            gap: 1rem;
+            margin-top: 1.2rem;
+        }
+
+        .stat-card {
+            background: rgba(255, 255, 255, 0.06);
+            border-radius: 12px;
+            padding: 0.9rem 1rem;
+            border: 1px solid rgba(255, 255, 255, 0.08);
+        }
+
+        .stat-card h4 {
+            font-size: 0.85rem;
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+            margin-bottom: 0.5rem;
+            color: #ffdd57;
+        }
+
+        .stat-card p {
+            font-size: 1.05rem;
+            font-weight: 500;
+            color: #f5f5f5;
+        }
+
+        .bar-chart {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+            gap: 0.75rem;
+            margin-top: 1rem;
+        }
+
+        .bar {
+            display: flex;
+            flex-direction: column;
+            gap: 0.4rem;
+        }
+
+        .bar-label {
+            font-size: 0.9rem;
+            opacity: 0.75;
+        }
+
+        .bar-track {
+            height: 10px;
+            background: rgba(255, 255, 255, 0.1);
+            border-radius: 999px;
+            overflow: hidden;
+        }
+
+        .bar-fill {
+            height: 100%;
+            background: linear-gradient(90deg, #ffd700, #ff8c00);
+        }
+
+        .digit-stream {
+            margin-top: 1rem;
+            font-family: 'JetBrains Mono', 'SFMono-Regular', Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+            font-size: 0.95rem;
+            color: #ffef9f;
+            background: rgba(0, 0, 0, 0.45);
+            border-radius: 12px;
+            padding: 1rem;
+            border: 1px solid rgba(255, 255, 255, 0.08);
+            max-height: 180px;
+            overflow: auto;
+            word-break: break-all;
+        }
+
+        .legend {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.75rem;
+            margin-top: 0.75rem;
+            font-size: 0.85rem;
+            opacity: 0.75;
+        }
+
+        .legend span {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.35rem;
+        }
+
+        .legend .color-box {
+            width: 14px;
+            height: 14px;
+            border-radius: 4px;
+            display: inline-block;
+        }
+
+        .back-link {
+            position: fixed;
+            top: 1.5rem;
+            left: 1.5rem;
+            background: rgba(255, 215, 0, 0.12);
+            border: 1px solid #ffd700;
+            border-radius: 10px;
+            padding: 0.8rem 1.4rem;
+            color: #ffd700;
+            text-decoration: none;
+            font-weight: 500;
+            transition: all 0.25s ease;
+            z-index: 10;
+        }
+
+        .back-link:hover {
+            background: rgba(255, 215, 0, 0.24);
+            transform: translateY(-1px);
+        }
+
+        @media (max-width: 768px) {
+            .container {
+                padding: 2rem 1.2rem 3rem;
+            }
+
+            .demo-container {
+                padding: 1.25rem;
+            }
+
+            input[type="range"] {
+                width: 160px;
+            }
+
+            canvas {
+                width: 100% !important;
+            }
+        }
+    </style>
+</head>
+<body>
+    <a href="./index.html" class="back-link">← Interactive Demo Hub</a>
+
+    <div class="container">
+        <header class="header">
+            <h1>Chapter 4 Interactive Experiments</h1>
+            <p>
+                Systems based on numbers reveal that even familiar arithmetic processes can behave like complex programs. Explore
+                five laboratories that turn digit sequences into living patterns, from binary counting tapes to chaotic logistic maps.
+            </p>
+        </header>
+
+        <section class="demo-section" id="binary-explorer">
+            <h2 class="demo-title"><span class="icon">①</span>Binary Expansion Pattern Explorer</h2>
+            <p class="demo-description">
+                Stack the digit expansions of counting numbers and exponential sequences to expose nested regularities or apparent
+                randomness. Change the base, watch the tape extend, and quantify how structured the columns remain.
+            </p>
+            <div class="demo-container">
+                <div class="controls">
+                    <div class="control-group">
+                        <label for="binary-sequence">Sequence</label>
+                        <select id="binary-sequence">
+                            <option value="count">Counting (n)</option>
+                            <option value="powers3">Powers of 3 (3ⁿ)</option>
+                            <option value="powers5">Powers of 5 (5ⁿ)</option>
+                        </select>
+                    </div>
+                    <div class="control-group">
+                        <label for="binary-base">Base <span id="binary-base-display">2</span></label>
+                        <input type="range" id="binary-base" min="2" max="10" step="1" value="2">
+                    </div>
+                    <div class="control-group">
+                        <label for="binary-rows">Rows <span id="binary-rows-display">32</span></label>
+                        <input type="range" id="binary-rows" min="8" max="96" step="1" value="32">
+                    </div>
+                    <div class="control-group">
+                        <label for="binary-width">Digits Shown <span id="binary-width-display">16</span></label>
+                        <input type="range" id="binary-width" min="4" max="32" step="1" value="16">
+                    </div>
+                    <button class="btn" id="binary-play">Play</button>
+                    <button class="btn secondary" id="binary-step">Step</button>
+                    <button class="btn secondary" id="binary-reset">Reset</button>
+                </div>
+                <div class="canvas-container">
+                    <canvas id="binary-canvas" width="900" height="420"></canvas>
+                    <div class="legend" id="binary-legend"></div>
+                </div>
+                <div class="info-panel">
+                    <h3>Digit Diagnostics</h3>
+                    <div class="stat-grid">
+                        <div class="stat-card">
+                            <h4>Entropy</h4>
+                            <p id="binary-entropy">–</p>
+                        </div>
+                        <div class="stat-card">
+                            <h4>Column Transition Rate</h4>
+                            <p id="binary-transitions">–</p>
+                        </div>
+                        <div class="stat-card">
+                            <h4>Distinct Column Patterns</h4>
+                            <p id="binary-patterns">–</p>
+                        </div>
+                    </div>
+                    <p>
+                        Transition rate measures how often digits flip between adjacent rows, while entropy captures the diversity of
+                        digits across the tape. Powers with large exponents typically resemble random sources, unlike the nested
+                        structure visible when counting in base 2.
+                    </p>
+                </div>
+            </div>
+        </section>
+
+        <section class="demo-section" id="recurrence-lab">
+            <h2 class="demo-title"><span class="icon">②</span>Recurrence Sequence Dynamics</h2>
+            <p class="demo-description">
+                Iterate classical and fast-growing recurrences, then view their digit tapes in any base. Compare linear growth to
+                explosive Ackermann-style behavior and nonlinear modular dynamics.
+            </p>
+            <div class="demo-container">
+                <div class="controls">
+                    <div class="control-group">
+                        <label for="recurrence-sequence">Recurrence</label>
+                        <select id="recurrence-sequence">
+                            <option value="fibonacci">Fibonacci</option>
+                            <option value="sylvester">Sylvester (aₙ₊₁ = aₙ(aₙ−1)+1)</option>
+                            <option value="nonlinear">Nonlinear Modular</option>
+                        </select>
+                    </div>
+                    <div class="control-group">
+                        <label for="recurrence-base">Base <span id="recurrence-base-display">10</span></label>
+                        <input type="range" id="recurrence-base" min="2" max="12" step="1" value="10">
+                    </div>
+                    <div class="control-group">
+                        <label for="recurrence-terms">Terms <span id="recurrence-terms-display">24</span></label>
+                        <input type="range" id="recurrence-terms" min="6" max="48" step="1" value="24">
+                    </div>
+                    <div class="control-group">
+                        <label for="recurrence-width">Digits Shown <span id="recurrence-width-display">20</span></label>
+                        <input type="range" id="recurrence-width" min="4" max="36" step="1" value="20">
+                    </div>
+                    <button class="btn" id="recurrence-play">Play</button>
+                    <button class="btn secondary" id="recurrence-reset">Reset</button>
+                </div>
+                <div class="canvas-container">
+                    <canvas id="recurrence-canvas" width="900" height="420"></canvas>
+                    <div class="legend" id="recurrence-legend"></div>
+                </div>
+                <div class="info-panel">
+                    <h3>Sequence Metrics</h3>
+                    <div class="stat-grid">
+                        <div class="stat-card">
+                            <h4>Average Digit Entropy</h4>
+                            <p id="recurrence-entropy">–</p>
+                        </div>
+                        <div class="stat-card">
+                            <h4>Growth per Step</h4>
+                            <p id="recurrence-growth">–</p>
+                        </div>
+                        <div class="stat-card">
+                            <h4>Last Term (Approx.)</h4>
+                            <p id="recurrence-last">–</p>
+                        </div>
+                    </div>
+                    <p>
+                        The Sylvester recurrence produces astronomically large values after only a few steps, while the nonlinear
+                        modular system settles into complex but bounded digit patterns. Entropy approximates how evenly digits are
+                        distributed in the rendered tape.
+                    </p>
+                </div>
+            </div>
+        </section>
+
+        <section class="demo-section" id="prime-sieve">
+            <h2 class="demo-title"><span class="icon">③</span>Prime Sieve Cellular Automaton</h2>
+            <p class="demo-description">
+                Watch a sieve-like automaton discover the primes. Each iteration marks multiples of the current base prime, revealing
+                the seemingly erratic spacing of primes within a regular scanning procedure.
+            </p>
+            <div class="demo-container">
+                <div class="controls">
+                    <div class="control-group">
+                        <label for="prime-limit">Limit <span id="prime-limit-display">120</span></label>
+                        <input type="range" id="prime-limit" min="40" max="360" step="10" value="120">
+                    </div>
+                    <button class="btn" id="prime-play">Play</button>
+                    <button class="btn secondary" id="prime-step">Step</button>
+                    <button class="btn secondary" id="prime-reset">Reset</button>
+                </div>
+                <div class="canvas-container">
+                    <canvas id="prime-canvas" width="900" height="360"></canvas>
+                </div>
+                <div class="info-panel">
+                    <h3>Sieve Status</h3>
+                    <div class="stat-grid">
+                        <div class="stat-card">
+                            <h4>Primes Found</h4>
+                            <p id="prime-count">–</p>
+                        </div>
+                        <div class="stat-card">
+                            <h4>Prime Density</h4>
+                            <p id="prime-density">–</p>
+                        </div>
+                        <div class="stat-card">
+                            <h4>Latest Prime</h4>
+                            <p id="prime-latest">–</p>
+                        </div>
+                        <div class="stat-card">
+                            <h4>Last Prime Gap</h4>
+                            <p id="prime-gap">–</p>
+                        </div>
+                    </div>
+                    <p>
+                        The automaton follows Eratosthenes' logic: sweep left to right, elevate a new prime, then eliminate its
+                        multiples. The prime density converges slowly toward 0 as the limit increases, illustrating the erratic yet
+                        structured spacing of primes.
+                    </p>
+                </div>
+            </div>
+        </section>
+
+        <section class="demo-section" id="constant-randomness">
+            <h2 class="demo-title"><span class="icon">④</span>Digits-of-Constants Randomness Lab</h2>
+            <p class="demo-description">
+                Sample digits from π, e, or √2 and run quick uniformity checks. Slide across the stream, measure entropy, and inspect
+                frequency histograms that hint at built-in randomness.
+            </p>
+            <div class="demo-container">
+                <div class="controls">
+                    <div class="control-group">
+                        <label for="constants-constant">Constant</label>
+                        <select id="constants-constant">
+                            <option value="pi">π</option>
+                            <option value="e">e</option>
+                            <option value="sqrt2">√2</option>
+                        </select>
+                    </div>
+                    <div class="control-group">
+                        <label for="constants-start">Start Offset <span id="constants-start-display">0</span></label>
+                        <input type="range" id="constants-start" min="0" max="300" step="5" value="0">
+                    </div>
+                    <div class="control-group">
+                        <label for="constants-count">Digits Sampled <span id="constants-count-display">120</span></label>
+                        <input type="range" id="constants-count" min="40" max="360" step="10" value="120">
+                    </div>
+                </div>
+                <div class="bar-chart" id="constants-bars"></div>
+                <div class="digit-stream" id="constants-stream"></div>
+                <div class="info-panel">
+                    <h3>Randomness Indicators</h3>
+                    <div class="stat-grid">
+                        <div class="stat-card">
+                            <h4>Normalized Entropy</h4>
+                            <p id="constants-entropy">–</p>
+                        </div>
+                        <div class="stat-card">
+                            <h4>Chi-Squared vs Uniform</h4>
+                            <p id="constants-chi">–</p>
+                        </div>
+                        <div class="stat-card">
+                            <h4>Max Digit Deviation</h4>
+                            <p id="constants-deviation">–</p>
+                        </div>
+                    </div>
+                    <p>
+                        For a perfectly random source each digit would appear 10% of the time. π, e, and √2 pass basic frequency tests
+                        across modest windows, though deeper randomness questions remain unsolved.
+                    </p>
+                </div>
+            </div>
+        </section>
+
+        <section class="demo-section" id="chaotic-map">
+            <h2 class="demo-title"><span class="icon">⑤</span>Chaotic Map Digit Tracker</h2>
+            <p class="demo-description">
+                Iterate the logistic map and follow both its real-valued trajectory and the evolving digit stream. Estimate the
+                Lyapunov exponent and see how sensitive parameters feed apparent randomness in the digits.
+            </p>
+            <div class="demo-container">
+                <div class="controls">
+                    <div class="control-group">
+                        <label for="chaos-r">Growth Rate r <span id="chaos-r-display">3.80</span></label>
+                        <input type="range" id="chaos-r" min="3.0" max="4.0" step="0.01" value="3.8">
+                    </div>
+                    <div class="control-group">
+                        <label for="chaos-x0">Initial x₀</label>
+                        <input type="number" id="chaos-x0" min="0.001" max="0.999" step="0.001" value="0.215">
+                    </div>
+                    <div class="control-group">
+                        <label for="chaos-steps">Iterations <span id="chaos-steps-display">120</span></label>
+                        <input type="range" id="chaos-steps" min="30" max="240" step="10" value="120">
+                    </div>
+                    <button class="btn" id="chaos-run">Recompute</button>
+                </div>
+                <div class="canvas-container">
+                    <canvas id="chaos-time-canvas" width="900" height="220"></canvas>
+                    <canvas id="chaos-digit-canvas" width="900" height="360"></canvas>
+                </div>
+                <div class="info-panel">
+                    <h3>Chaos Metrics</h3>
+                    <div class="stat-grid">
+                        <div class="stat-card">
+                            <h4>Lyapunov Estimate</h4>
+                            <p id="chaos-lyapunov">–</p>
+                        </div>
+                        <div class="stat-card">
+                            <h4>Value Spread (σ)</h4>
+                            <p id="chaos-spread">–</p>
+                        </div>
+                        <div class="stat-card">
+                            <h4>Digit Entropy</h4>
+                            <p id="chaos-entropy">–</p>
+                        </div>
+                    </div>
+                    <p>
+                        Positive Lyapunov exponents indicate sensitive dependence on initial conditions. The digit plot shows why
+                        chaotic maps look random even though the underlying iteration is entirely deterministic.
+                    </p>
+                </div>
+            </div>
+        </section>
+    </div>
+
+    <script src="chapter4-demos.js"></script>
+</body>
+</html>

--- a/interactive/chapter4-demos.js
+++ b/interactive/chapter4-demos.js
@@ -1,0 +1,901 @@
+(() => {
+    'use strict';
+
+    const CONSTANT_DIGITS = {
+        pi: {
+            label: 'π',
+            digits: '314159265358979323846264338327950288419716939937510582097494459230781640628620899862803482534211706798214808651328230664709384460955058223172535940812848111745028410270193852110555964462294895493038196442881097566593344612847564823378678316527120190914564856692346034861045432664821339360726024914127372458700660631558817488152092096282925409171536436789259036001133053054882046652138414695194151160943305727036575959195'
+        },
+        e: {
+            label: 'e',
+            digits: '271828182845904523536028747135266249775724709369995957496696762772407663035354759457138217852516642742746639193200305992181741359662904357290033429526059563073813232862794349076323382988075319525101901157383418793070215408914993488416750924476146066808226480016847741185374234544243710753907774499206955170276183860626133138458300075204493382656029760673711320070932870912744374704723069697720931014169283681902551510865'
+        },
+        sqrt2: {
+            label: '√2',
+            digits: '141421356237309504880168872420969807856967187537694807317667973799073247846210703885038753432764157273501384623091229702492483605585073721264412149709993583141322266592750559275579995050115278206057147010955997160597027453459686201472851741864088919860955232923048430871432145083976260362799525140798968725339654633180882964062061525835239505474575028775996172983557522033753185701135437460340849884716038689997069900481'
+        }
+    };
+
+    function digitLabel(digit) {
+        return digit < 10 ? digit.toString() : String.fromCharCode(55 + digit);
+    }
+
+    function bigIntToDigits(value, base, width) {
+        const digits = new Array(width).fill(0);
+        const bigBase = BigInt(base);
+        let index = width - 1;
+        let working = value < 0n ? -value : value;
+        while (working > 0n && index >= 0) {
+            digits[index] = Number(working % bigBase);
+            working /= bigBase;
+            index--;
+        }
+        return digits;
+    }
+
+    function computeDigitCounts(matrix, base) {
+        const counts = new Array(base).fill(0);
+        for (const row of matrix) {
+            for (const digit of row) {
+                if (digit >= 0 && digit < base) {
+                    counts[digit] += 1;
+                }
+            }
+        }
+        return counts;
+    }
+
+    function computeEntropy(counts, base) {
+        const total = counts.reduce((a, b) => a + b, 0);
+        if (!total) {
+            return 0;
+        }
+        let entropy = 0;
+        for (const count of counts) {
+            if (count === 0) continue;
+            const p = count / total;
+            entropy -= p * Math.log2(p);
+        }
+        const maxEntropy = Math.log2(Math.min(base, counts.length));
+        return entropy / (maxEntropy || 1);
+    }
+
+    function computeTransitionRate(matrix) {
+        if (matrix.length < 2) return 0;
+        const rows = matrix.length;
+        const cols = matrix[0].length;
+        let changes = 0;
+        for (let y = 1; y < rows; y++) {
+            for (let x = 0; x < cols; x++) {
+                if (matrix[y][x] !== matrix[y - 1][x]) {
+                    changes += 1;
+                }
+            }
+        }
+        return changes / ((rows - 1) * cols);
+    }
+
+    function distinctColumnPatterns(matrix) {
+        const cols = matrix[0]?.length || 0;
+        const signatures = new Set();
+        for (let x = 0; x < cols; x++) {
+            let signature = '';
+            for (let y = 0; y < matrix.length; y++) {
+                signature += matrix[y][x];
+            }
+            signatures.add(signature);
+        }
+        return signatures.size;
+    }
+
+    function getDigitColor(digit, base) {
+        if (base === 2) {
+            return digit === 1 ? '#ffd700' : '#111111';
+        }
+        const ratio = base > 1 ? digit / (base - 1) : 0;
+        const hue = 40 + ratio * 220;
+        const lightness = 25 + ratio * 40;
+        return `hsl(${hue}, 70%, ${lightness}%)`;
+    }
+
+    function drawDigitMatrix(ctx, matrix, base) {
+        const rows = matrix.length;
+        const cols = matrix[0]?.length || 0;
+        ctx.save();
+        ctx.fillStyle = '#050505';
+        ctx.fillRect(0, 0, ctx.canvas.width, ctx.canvas.height);
+        if (!rows || !cols) {
+            ctx.restore();
+            return;
+        }
+        const cellWidth = ctx.canvas.width / cols;
+        const cellHeight = ctx.canvas.height / rows;
+        for (let y = 0; y < rows; y++) {
+            for (let x = 0; x < cols; x++) {
+                const digit = matrix[y][x];
+                ctx.fillStyle = getDigitColor(digit, base);
+                ctx.fillRect(x * cellWidth, y * cellHeight, Math.ceil(cellWidth) + 0.5, Math.ceil(cellHeight) + 0.5);
+            }
+        }
+        ctx.globalAlpha = 0.15;
+        ctx.strokeStyle = '#ffffff';
+        ctx.lineWidth = 0.5;
+        for (let x = 0; x <= cols; x++) {
+            ctx.beginPath();
+            ctx.moveTo(x * cellWidth, 0);
+            ctx.lineTo(x * cellWidth, ctx.canvas.height);
+            ctx.stroke();
+        }
+        for (let y = 0; y <= rows; y++) {
+            ctx.beginPath();
+            ctx.moveTo(0, y * cellHeight);
+            ctx.lineTo(ctx.canvas.width, y * cellHeight);
+            ctx.stroke();
+        }
+        ctx.restore();
+    }
+
+    function updateLegend(container, base) {
+        if (!container) return;
+        const digitsToShow = Math.min(base, 16);
+        const pieces = [];
+        for (let digit = 0; digit < digitsToShow; digit++) {
+            const color = getDigitColor(digit, base);
+            pieces.push(`<span><span class="color-box" style="background:${color}"></span>${digitLabel(digit)}</span>`);
+        }
+        container.innerHTML = pieces.join('');
+    }
+
+    function formatEntropy(value) {
+        if (!isFinite(value)) return '–';
+        return `${value.toFixed(3)}`;
+    }
+
+    function formatPercentage(value) {
+        return `${(value * 100).toFixed(1)}%`;
+    }
+
+    function formatLargeNumber(value) {
+        const str = value.toString();
+        if (str.length <= 12) return str;
+        return `${str.slice(0, 6)}… (${str.length} digits)`;
+    }
+
+    function chiSquaredStatistic(counts, expected) {
+        let chi = 0;
+        for (let i = 0; i < counts.length; i++) {
+            const diff = counts[i] - expected;
+            chi += (diff * diff) / (expected || 1);
+        }
+        return chi;
+    }
+
+    function standardDeviation(values) {
+        if (!values.length) return 0;
+        const mean = values.reduce((a, b) => a + b, 0) / values.length;
+        const variance = values.reduce((acc, value) => acc + (value - mean) ** 2, 0) / values.length;
+        return Math.sqrt(variance);
+    }
+
+    class BinaryExpansionDemo {
+        constructor() {
+            this.canvas = document.getElementById('binary-canvas');
+            this.ctx = this.canvas.getContext('2d');
+            this.sequenceSelect = document.getElementById('binary-sequence');
+            this.baseSlider = document.getElementById('binary-base');
+            this.baseDisplay = document.getElementById('binary-base-display');
+            this.rowsSlider = document.getElementById('binary-rows');
+            this.rowsDisplay = document.getElementById('binary-rows-display');
+            this.widthSlider = document.getElementById('binary-width');
+            this.widthDisplay = document.getElementById('binary-width-display');
+            this.playBtn = document.getElementById('binary-play');
+            this.stepBtn = document.getElementById('binary-step');
+            this.resetBtn = document.getElementById('binary-reset');
+            this.legend = document.getElementById('binary-legend');
+            this.entropyDisplay = document.getElementById('binary-entropy');
+            this.transitionsDisplay = document.getElementById('binary-transitions');
+            this.patternDisplay = document.getElementById('binary-patterns');
+            this.isPlaying = false;
+            this.timer = null;
+
+            this.attachListeners();
+            this.render();
+        }
+
+        attachListeners() {
+            const scheduleRender = () => this.render();
+            this.sequenceSelect.addEventListener('change', scheduleRender);
+            this.baseSlider.addEventListener('input', () => {
+                this.baseDisplay.textContent = this.baseSlider.value;
+                scheduleRender();
+            });
+            this.rowsSlider.addEventListener('input', () => {
+                this.rowsDisplay.textContent = this.rowsSlider.value;
+                if (!this.isPlaying) scheduleRender();
+            });
+            this.widthSlider.addEventListener('input', () => {
+                this.widthDisplay.textContent = this.widthSlider.value;
+                scheduleRender();
+            });
+            this.playBtn.addEventListener('click', () => this.togglePlay());
+            this.stepBtn.addEventListener('click', () => {
+                this.stop();
+                this.incrementRows();
+            });
+            this.resetBtn.addEventListener('click', () => this.reset());
+        }
+
+        togglePlay() {
+            if (this.isPlaying) {
+                this.stop();
+            } else {
+                this.isPlaying = true;
+                this.playBtn.textContent = 'Pause';
+                this.loop();
+            }
+        }
+
+        stop() {
+            this.isPlaying = false;
+            this.playBtn.textContent = 'Play';
+            if (this.timer) {
+                clearTimeout(this.timer);
+                this.timer = null;
+            }
+        }
+
+        incrementRows() {
+            const maxRows = parseInt(this.rowsSlider.max, 10);
+            let current = parseInt(this.rowsSlider.value, 10);
+            if (current < maxRows) {
+                current += 1;
+                this.rowsSlider.value = current;
+                this.rowsDisplay.textContent = current;
+            }
+            this.render();
+        }
+
+        loop() {
+            if (!this.isPlaying) return;
+            this.incrementRows();
+            this.timer = setTimeout(() => this.loop(), 600);
+        }
+
+        reset() {
+            this.stop();
+            this.baseSlider.value = '2';
+            this.rowsSlider.value = '32';
+            this.widthSlider.value = '16';
+            this.baseDisplay.textContent = '2';
+            this.rowsDisplay.textContent = '32';
+            this.widthDisplay.textContent = '16';
+            this.sequenceSelect.value = 'count';
+            this.render();
+        }
+
+        generateMatrix() {
+            const base = parseInt(this.baseSlider.value, 10);
+            const rows = parseInt(this.rowsSlider.value, 10);
+            const width = parseInt(this.widthSlider.value, 10);
+            const sequence = this.sequenceSelect.value;
+            const matrix = [];
+            for (let i = 0; i < rows; i++) {
+                let value = 0n;
+                switch (sequence) {
+                    case 'count':
+                        value = BigInt(i);
+                        break;
+                    case 'powers3':
+                        value = 3n ** BigInt(i);
+                        break;
+                    case 'powers5':
+                        value = 5n ** BigInt(i);
+                        break;
+                }
+                matrix.push(bigIntToDigits(value, base, width));
+            }
+            return matrix;
+        }
+
+        render() {
+            const base = parseInt(this.baseSlider.value, 10);
+            const matrix = this.generateMatrix();
+            drawDigitMatrix(this.ctx, matrix, base);
+            updateLegend(this.legend, base);
+            const counts = computeDigitCounts(matrix, base);
+            const entropy = computeEntropy(counts, base);
+            const transitions = computeTransitionRate(matrix);
+            const patterns = distinctColumnPatterns(matrix);
+            this.entropyDisplay.textContent = `${formatEntropy(entropy)} (of 1.000)`;
+            this.transitionsDisplay.textContent = formatPercentage(transitions);
+            this.patternDisplay.textContent = patterns.toString();
+        }
+    }
+
+    const RECURRENCE_CONFIG = {
+        fibonacci: {
+            label: 'Fibonacci',
+            maxTerms: 60,
+            defaultTerms: 24
+        },
+        sylvester: {
+            label: 'Sylvester',
+            maxTerms: 18,
+            defaultTerms: 10
+        },
+        nonlinear: {
+            label: 'Nonlinear Modular',
+            maxTerms: 60,
+            defaultTerms: 30
+        }
+    };
+
+    class RecurrenceSequenceDemo {
+        constructor() {
+            this.canvas = document.getElementById('recurrence-canvas');
+            this.ctx = this.canvas.getContext('2d');
+            this.sequenceSelect = document.getElementById('recurrence-sequence');
+            this.baseSlider = document.getElementById('recurrence-base');
+            this.baseDisplay = document.getElementById('recurrence-base-display');
+            this.termsSlider = document.getElementById('recurrence-terms');
+            this.termsDisplay = document.getElementById('recurrence-terms-display');
+            this.widthSlider = document.getElementById('recurrence-width');
+            this.widthDisplay = document.getElementById('recurrence-width-display');
+            this.playBtn = document.getElementById('recurrence-play');
+            this.resetBtn = document.getElementById('recurrence-reset');
+            this.legend = document.getElementById('recurrence-legend');
+            this.entropyDisplay = document.getElementById('recurrence-entropy');
+            this.growthDisplay = document.getElementById('recurrence-growth');
+            this.lastDisplay = document.getElementById('recurrence-last');
+            this.isPlaying = false;
+            this.timer = null;
+            this.values = [];
+
+            this.attachListeners();
+            this.applyConfig();
+            this.render();
+        }
+
+        attachListeners() {
+            this.sequenceSelect.addEventListener('change', () => {
+                this.applyConfig();
+                this.render();
+            });
+            this.baseSlider.addEventListener('input', () => {
+                this.baseDisplay.textContent = this.baseSlider.value;
+                this.render();
+            });
+            this.termsSlider.addEventListener('input', () => {
+                this.termsDisplay.textContent = this.termsSlider.value;
+                if (!this.isPlaying) this.render();
+            });
+            this.widthSlider.addEventListener('input', () => {
+                this.widthDisplay.textContent = this.widthSlider.value;
+                this.render();
+            });
+            this.playBtn.addEventListener('click', () => this.togglePlay());
+            this.resetBtn.addEventListener('click', () => this.reset());
+        }
+
+        applyConfig() {
+            const config = RECURRENCE_CONFIG[this.sequenceSelect.value];
+            this.termsSlider.max = config.maxTerms.toString();
+            if (parseInt(this.termsSlider.value, 10) > config.maxTerms) {
+                this.termsSlider.value = config.maxTerms.toString();
+            }
+            if (!this.isPlaying) {
+                this.termsSlider.value = config.defaultTerms.toString();
+            }
+            this.termsDisplay.textContent = this.termsSlider.value;
+        }
+
+        togglePlay() {
+            if (this.isPlaying) {
+                this.stop();
+            } else {
+                this.isPlaying = true;
+                this.playBtn.textContent = 'Pause';
+                this.loop();
+            }
+        }
+
+        stop() {
+            this.isPlaying = false;
+            this.playBtn.textContent = 'Play';
+            if (this.timer) {
+                clearTimeout(this.timer);
+                this.timer = null;
+            }
+        }
+
+        loop() {
+            if (!this.isPlaying) return;
+            const maxTerms = parseInt(this.termsSlider.max, 10);
+            let current = parseInt(this.termsSlider.value, 10);
+            if (current < maxTerms) {
+                current += 1;
+                this.termsSlider.value = current.toString();
+                this.termsDisplay.textContent = this.termsSlider.value;
+                this.render();
+                this.timer = setTimeout(() => this.loop(), 700);
+            } else {
+                this.stop();
+            }
+        }
+
+        reset() {
+            this.stop();
+            this.applyConfig();
+            this.baseSlider.value = '10';
+            this.baseDisplay.textContent = '10';
+            this.widthSlider.value = '20';
+            this.widthDisplay.textContent = '20';
+            this.render();
+        }
+
+        generateValues() {
+            const terms = parseInt(this.termsSlider.value, 10);
+            const type = this.sequenceSelect.value;
+            const values = [];
+            if (type === 'fibonacci') {
+                values.push(0n, 1n);
+                for (let i = 2; i < terms; i++) {
+                    values.push(values[i - 1] + values[i - 2]);
+                }
+            } else if (type === 'sylvester') {
+                values.push(2n);
+                for (let i = 1; i < terms; i++) {
+                    const prev = values[i - 1];
+                    values.push(prev * (prev - 1n) + 1n);
+                }
+            } else {
+                values.push(1n, 3n);
+                const modulus = 10n ** 12n;
+                for (let i = 2; i < terms; i++) {
+                    const next = (values[i - 1] * values[i - 1] + values[i - 2] + BigInt(i)) % modulus;
+                    values.push(next);
+                }
+            }
+            return values.slice(0, terms);
+        }
+
+        render() {
+            const base = parseInt(this.baseSlider.value, 10);
+            const width = parseInt(this.widthSlider.value, 10);
+            this.values = this.generateValues();
+            const matrix = this.values.map(value => bigIntToDigits(value, base, width));
+            drawDigitMatrix(this.ctx, matrix, base);
+            updateLegend(this.legend, base);
+            const counts = computeDigitCounts(matrix, base);
+            const entropy = computeEntropy(counts, base);
+            this.entropyDisplay.textContent = `${formatEntropy(entropy)} (of 1.000)`;
+            if (this.values.length > 1) {
+                const first = this.values[1] === 0n ? this.values[2] || 1n : this.values[1];
+                const last = this.values[this.values.length - 1];
+                const growth = (last.toString().length - first.toString().length) / Math.max(1, this.values.length - 1);
+                this.growthDisplay.textContent = `${growth.toFixed(2)} digits/step`;
+                this.lastDisplay.textContent = formatLargeNumber(last);
+            } else if (this.values.length === 1) {
+                this.growthDisplay.textContent = '0.00 digits/step';
+                this.lastDisplay.textContent = formatLargeNumber(this.values[0]);
+            } else {
+                this.growthDisplay.textContent = '–';
+                this.lastDisplay.textContent = '–';
+            }
+        }
+    }
+
+    class PrimeSieveDemo {
+        constructor() {
+            this.canvas = document.getElementById('prime-canvas');
+            this.ctx = this.canvas.getContext('2d');
+            this.limitSlider = document.getElementById('prime-limit');
+            this.limitDisplay = document.getElementById('prime-limit-display');
+            this.playBtn = document.getElementById('prime-play');
+            this.stepBtn = document.getElementById('prime-step');
+            this.resetBtn = document.getElementById('prime-reset');
+            this.countDisplay = document.getElementById('prime-count');
+            this.densityDisplay = document.getElementById('prime-density');
+            this.latestDisplay = document.getElementById('prime-latest');
+            this.gapDisplay = document.getElementById('prime-gap');
+            this.isRunning = false;
+            this.timer = null;
+
+            this.attachListeners();
+            this.reset();
+        }
+
+        attachListeners() {
+            this.limitSlider.addEventListener('input', () => {
+                this.limitDisplay.textContent = this.limitSlider.value;
+            });
+            this.limitSlider.addEventListener('change', () => this.reset());
+            this.playBtn.addEventListener('click', () => this.togglePlay());
+            this.stepBtn.addEventListener('click', () => {
+                this.stop();
+                this.step();
+                this.draw();
+                this.updateStats();
+            });
+            this.resetBtn.addEventListener('click', () => this.reset());
+        }
+
+        togglePlay() {
+            if (this.isRunning) {
+                this.stop();
+            } else {
+                this.isRunning = true;
+                this.playBtn.textContent = 'Pause';
+                this.loop();
+            }
+        }
+
+        stop() {
+            this.isRunning = false;
+            this.playBtn.textContent = 'Play';
+            if (this.timer) {
+                clearTimeout(this.timer);
+                this.timer = null;
+            }
+        }
+
+        reset() {
+            this.stop();
+            this.limit = parseInt(this.limitSlider.value, 10);
+            this.numbers = [];
+            for (let value = 2; value <= this.limit; value++) {
+                this.numbers.push({ value, state: 'unknown' });
+            }
+            this.primes = [];
+            this.currentPrimeIndex = null;
+            this.nextMultiple = null;
+            this.complete = false;
+            this.draw();
+            this.updateStats();
+        }
+
+        loop() {
+            if (!this.isRunning) return;
+            const progressed = this.step();
+            this.draw();
+            this.updateStats();
+            if (!progressed || this.complete) {
+                this.stop();
+                return;
+            }
+            this.timer = setTimeout(() => this.loop(), 320);
+        }
+
+        step() {
+            if (this.complete) return false;
+            if (this.currentPrimeIndex === null) {
+                this.currentPrimeIndex = this.findNextPrimeIndex(-1);
+                if (this.currentPrimeIndex === null) {
+                    this.complete = true;
+                    return false;
+                }
+                this.promotePrime(this.currentPrimeIndex);
+            }
+            if (this.nextMultiple === null) {
+                const primeValue = this.numbers[this.currentPrimeIndex].value;
+                const start = primeValue * primeValue;
+                this.nextMultiple = start <= this.limit ? start : null;
+                if (this.nextMultiple === null) {
+                    this.currentPrimeIndex = this.findNextPrimeIndex(this.currentPrimeIndex);
+                    if (this.currentPrimeIndex === null) {
+                        this.complete = true;
+                        return false;
+                    }
+                    this.promotePrime(this.currentPrimeIndex);
+                    return true;
+                }
+            }
+            const primeValue = this.numbers[this.currentPrimeIndex].value;
+            while (this.nextMultiple !== null && this.nextMultiple <= this.limit) {
+                const index = this.nextMultiple - 2;
+                if (this.numbers[index].state === 'unknown') {
+                    this.numbers[index].state = 'composite';
+                    this.nextMultiple += primeValue;
+                    return true;
+                }
+                this.nextMultiple += primeValue;
+            }
+            this.nextMultiple = null;
+            const nextIndex = this.findNextPrimeIndex(this.currentPrimeIndex);
+            if (nextIndex === null) {
+                this.complete = true;
+                return false;
+            }
+            this.promotePrime(nextIndex);
+            return true;
+        }
+
+        promotePrime(index) {
+            const entry = this.numbers[index];
+            if (entry.state !== 'prime') {
+                entry.state = 'prime';
+                this.primes.push(entry.value);
+            }
+            this.currentPrimeIndex = index;
+            this.nextMultiple = null;
+        }
+
+        findNextPrimeIndex(startIndex) {
+            for (let i = startIndex + 1; i < this.numbers.length; i++) {
+                if (this.numbers[i].state === 'unknown') {
+                    return i;
+                }
+            }
+            return null;
+        }
+
+        draw() {
+            const ctx = this.ctx;
+            const width = ctx.canvas.width;
+            const height = ctx.canvas.height;
+            ctx.fillStyle = '#050505';
+            ctx.fillRect(0, 0, width, height);
+            const count = this.numbers.length;
+            if (!count) return;
+            const cols = Math.ceil(Math.sqrt(count));
+            const rows = Math.ceil(count / cols);
+            const cellWidth = width / cols;
+            const cellHeight = height / rows;
+            for (let i = 0; i < count; i++) {
+                const { value, state } = this.numbers[i];
+                const col = i % cols;
+                const row = Math.floor(i / cols);
+                const x = col * cellWidth;
+                const y = row * cellHeight;
+                let fill = '#3a3a3a';
+                if (state === 'prime') fill = '#ffd700';
+                if (state === 'composite') fill = '#1b1b1b';
+                if (this.currentPrimeIndex === i) fill = '#ff8c00';
+                ctx.fillStyle = fill;
+                ctx.fillRect(x + 1, y + 1, cellWidth - 2, cellHeight - 2);
+                ctx.fillStyle = '#aaaaaa';
+                ctx.font = `${Math.max(10, Math.floor(cellHeight * 0.32))}px 'Inter', sans-serif`;
+                ctx.globalAlpha = 0.6;
+                ctx.fillText(value.toString(), x + 4, y + cellHeight * 0.6);
+                ctx.globalAlpha = 1;
+            }
+        }
+
+        updateStats() {
+            const count = this.primes.length;
+            this.countDisplay.textContent = count.toString();
+            const density = count / Math.max(1, this.numbers.length);
+            this.densityDisplay.textContent = formatPercentage(density);
+            const latest = this.primes[count - 1];
+            this.latestDisplay.textContent = latest ? latest.toString() : '–';
+            if (count >= 2) {
+                const gap = this.primes[count - 1] - this.primes[count - 2];
+                this.gapDisplay.textContent = gap.toString();
+            } else {
+                this.gapDisplay.textContent = '–';
+            }
+        }
+    }
+
+    class ConstantRandomnessLab {
+        constructor() {
+            this.constantSelect = document.getElementById('constants-constant');
+            this.startSlider = document.getElementById('constants-start');
+            this.startDisplay = document.getElementById('constants-start-display');
+            this.countSlider = document.getElementById('constants-count');
+            this.countDisplay = document.getElementById('constants-count-display');
+            this.barContainer = document.getElementById('constants-bars');
+            this.streamContainer = document.getElementById('constants-stream');
+            this.entropyDisplay = document.getElementById('constants-entropy');
+            this.chiDisplay = document.getElementById('constants-chi');
+            this.deviationDisplay = document.getElementById('constants-deviation');
+
+            this.attachListeners();
+            this.render();
+        }
+
+        attachListeners() {
+            this.constantSelect.addEventListener('change', () => this.render());
+            this.startSlider.addEventListener('input', () => {
+                this.startDisplay.textContent = this.startSlider.value;
+                this.render();
+            });
+            this.countSlider.addEventListener('input', () => {
+                this.countDisplay.textContent = this.countSlider.value;
+                this.render();
+            });
+        }
+
+        sampleDigits() {
+            const constant = this.constantSelect.value;
+            const data = CONSTANT_DIGITS[constant];
+            const start = parseInt(this.startSlider.value, 10);
+            const count = parseInt(this.countSlider.value, 10);
+            const digits = data.digits.slice(start, start + count);
+            return digits.split('').map(d => parseInt(d, 10));
+        }
+
+        renderBars(counts, total) {
+            const pieces = [];
+            for (let digit = 0; digit < counts.length; digit++) {
+                const frequency = counts[digit] / (total || 1);
+                const width = Math.round(frequency * 100);
+                pieces.push(`
+                    <div class="bar">
+                        <div class="bar-label">Digit ${digit}</div>
+                        <div class="bar-track"><div class="bar-fill" style="width:${width}%"></div></div>
+                        <div class="bar-label" style="font-size:0.8rem; opacity:0.65;">${(frequency * 100).toFixed(2)}%</div>
+                    </div>
+                `);
+            }
+            this.barContainer.innerHTML = pieces.join('');
+        }
+
+        renderStream(digits) {
+            const chunked = [];
+            for (let i = 0; i < digits.length; i += 4) {
+                chunked.push(digits.slice(i, i + 4).join(''));
+            }
+            this.streamContainer.textContent = chunked.join(' ');
+        }
+
+        render() {
+            const digits = this.sampleDigits();
+            if (!digits.length) {
+                this.barContainer.innerHTML = '';
+                this.streamContainer.textContent = '';
+                this.entropyDisplay.textContent = '–';
+                this.chiDisplay.textContent = '–';
+                this.deviationDisplay.textContent = '–';
+                return;
+            }
+            const counts = new Array(10).fill(0);
+            for (const digit of digits) {
+                if (!Number.isNaN(digit)) {
+                    counts[digit] += 1;
+                }
+            }
+            const entropy = computeEntropy(counts, 10);
+            const expected = digits.length / 10;
+            const chi = chiSquaredStatistic(counts, expected);
+            const maxDeviation = counts.reduce((max, count) => Math.max(max, Math.abs(count - expected)), 0);
+            this.renderBars(counts, digits.length);
+            this.renderStream(digits);
+            this.entropyDisplay.textContent = `${formatEntropy(entropy)} (of 1.000)`;
+            this.chiDisplay.textContent = chi.toFixed(2);
+            this.deviationDisplay.textContent = `${maxDeviation.toFixed(1)} digits`;
+        }
+    }
+
+    class ChaoticMapDemo {
+        constructor() {
+            this.rSlider = document.getElementById('chaos-r');
+            this.rDisplay = document.getElementById('chaos-r-display');
+            this.x0Input = document.getElementById('chaos-x0');
+            this.stepsSlider = document.getElementById('chaos-steps');
+            this.stepsDisplay = document.getElementById('chaos-steps-display');
+            this.timeCanvas = document.getElementById('chaos-time-canvas');
+            this.timeCtx = this.timeCanvas.getContext('2d');
+            this.digitCanvas = document.getElementById('chaos-digit-canvas');
+            this.digitCtx = this.digitCanvas.getContext('2d');
+            this.lyapunovDisplay = document.getElementById('chaos-lyapunov');
+            this.spreadDisplay = document.getElementById('chaos-spread');
+            this.entropyDisplay = document.getElementById('chaos-entropy');
+            this.runBtn = document.getElementById('chaos-run');
+
+            this.attachListeners();
+            this.render();
+        }
+
+        attachListeners() {
+            this.rSlider.addEventListener('input', () => {
+                this.rDisplay.textContent = parseFloat(this.rSlider.value).toFixed(2);
+                this.render();
+            });
+            this.stepsSlider.addEventListener('input', () => {
+                this.stepsDisplay.textContent = this.stepsSlider.value;
+                this.render();
+            });
+            this.x0Input.addEventListener('change', () => this.render());
+            this.runBtn.addEventListener('click', () => this.render());
+        }
+
+        iterate() {
+            let x = parseFloat(this.x0Input.value);
+            if (!Number.isFinite(x) || x <= 0 || x >= 1) {
+                x = 0.215;
+                this.x0Input.value = '0.215';
+            }
+            const r = parseFloat(this.rSlider.value);
+            const steps = parseInt(this.stepsSlider.value, 10);
+            const values = [];
+            for (let i = 0; i < steps; i++) {
+                x = r * x * (1 - x);
+                values.push(x);
+            }
+            return values;
+        }
+
+        drawTimeSeries(values) {
+            const ctx = this.timeCtx;
+            const width = ctx.canvas.width;
+            const height = ctx.canvas.height;
+            ctx.fillStyle = '#050505';
+            ctx.fillRect(0, 0, width, height);
+            if (!values.length) return;
+            ctx.strokeStyle = '#ffd700';
+            ctx.lineWidth = 2;
+            ctx.beginPath();
+            values.forEach((value, index) => {
+                const x = (index / (values.length - 1 || 1)) * width;
+                const y = height - value * height;
+                if (index === 0) ctx.moveTo(x, y);
+                else ctx.lineTo(x, y);
+            });
+            ctx.stroke();
+            ctx.fillStyle = '#777';
+            ctx.font = "12px 'Inter', sans-serif";
+            ctx.fillText('0', 6, height - 6);
+            ctx.fillText('1', 6, 14);
+        }
+
+        drawDigitTiles(values) {
+            const base = 10;
+            const width = 16;
+            const matrix = values.map(value => {
+                const digits = Math.abs(value).toFixed(16).split('.')[1] || '';
+                const slice = digits.slice(0, width).padEnd(width, '0');
+                return slice.split('').map(ch => parseInt(ch, 10));
+            });
+            drawDigitMatrix(this.digitCtx, matrix, base);
+        }
+
+        render() {
+            this.rDisplay.textContent = parseFloat(this.rSlider.value).toFixed(2);
+            this.stepsDisplay.textContent = this.stepsSlider.value;
+            const values = this.iterate();
+            this.drawTimeSeries(values);
+            this.drawDigitTiles(values);
+            if (!values.length) {
+                this.lyapunovDisplay.textContent = '–';
+                this.spreadDisplay.textContent = '–';
+                this.entropyDisplay.textContent = '–';
+                return;
+            }
+            const r = parseFloat(this.rSlider.value);
+            let sumLyapunov = 0;
+            const digitsMatrix = values.map(value => {
+                const digits = Math.abs(value).toFixed(16).split('.')[1] || '';
+                const slice = digits.slice(0, 16).padEnd(16, '0');
+                return slice.split('').map(ch => parseInt(ch, 10));
+            });
+            for (const value of values) {
+                const term = Math.abs(r * (1 - 2 * value));
+                if (term > 0) {
+                    sumLyapunov += Math.log(Math.abs(term));
+                }
+            }
+            const lyapunov = sumLyapunov / values.length;
+            this.lyapunovDisplay.textContent = lyapunov.toFixed(3);
+            const spread = standardDeviation(values);
+            this.spreadDisplay.textContent = spread.toFixed(3);
+            const counts = computeDigitCounts(digitsMatrix, 10);
+            const entropy = computeEntropy(counts, 10);
+            this.entropyDisplay.textContent = `${formatEntropy(entropy)} (of 1.000)`;
+        }
+    }
+
+    const initializeDemos = () => {
+        new BinaryExpansionDemo();
+        new RecurrenceSequenceDemo();
+        new PrimeSieveDemo();
+        new ConstantRandomnessLab();
+        new ChaoticMapDemo();
+    };
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', initializeDemos);
+    } else {
+        initializeDemos();
+    }
+})();

--- a/interactive/index.html
+++ b/interactive/index.html
@@ -109,17 +109,17 @@
             </div>
         </a>
         
-        <div class="demo-card" style="opacity: 0.5;">
-            <div class="demo-title">Chapter 3: Simple Programs (Coming Soon)</div>
+        <a href="chapter4-demos.html" class="demo-card">
+            <div class="demo-title">Chapter 4: Systems Based on Numbers</div>
             <div class="demo-description">
-                Explore the complete universe of elementary cellular automata, substitution systems, and other simple computational processes.
+                Manipulate number-based systems: binary expansion tapes, recurrence growth, a sieve-inspired prime automaton, digit randomness labs, and chaotic logistic maps.
             </div>
-        </div>
-        
+        </a>
+
         <div class="demo-card" style="opacity: 0.5;">
             <div class="demo-title">More Chapters (Coming Soon)</div>
             <div class="demo-description">
-                Additional interactive demonstrations covering two-dimensional systems, natural phenomena, and computational universality.
+                Additional interactive demonstrations covering multi-dimensional systems, natural phenomena, and computational universality.
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- add a dedicated Chapter 4 interactive page with five number-based experiments and supporting styling
- implement JavaScript engines for binary expansions, recurrence dynamics, sieve automation, digit randomness testing, and logistic map analysis
- surface the new demos in the interactive hub and main site navigation

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cb2cc46578832281e5c392acfead8a